### PR TITLE
Add missing CI for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
In PR #7 we changed the build system specifically to resolve issue #6 about the package not compiling on Python 3.11. However, we did not add CI for Python 3.11 and thus would not notice if we break the build for Python 3.11 again.